### PR TITLE
Add vite module federation support

### DIFF
--- a/pre-files/vite.config.js
+++ b/pre-files/vite.config.js
@@ -1,1 +1,6 @@
-import { defineConfig } from 'vite';\nimport react from '@vitejs/plugin-react';\n\nexport default defineConfig({\n  plugins: [react()],\n});
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/src/setup/devDeps.js
+++ b/src/setup/devDeps.js
@@ -2,6 +2,7 @@ const devDeps = [
   'pretty-quick',
   'vite',
   '@vitejs/plugin-react',
+  '@originjs/vite-plugin-federation',
   'husky',
   'dotenv',
   '@commitlint/config-conventional',

--- a/src/setup/init.js
+++ b/src/setup/init.js
@@ -10,6 +10,7 @@ const { setupZustand } = require('./zustand');
 const { setupStyles } = require('./styles');
 const { setupGit } = require('./gitInit');
 const { setupTesting } = require('./testing');
+const { setupModuleFederation } = require('./moduleFederation');
 const { createAtomicStructure } = require('../templates/atomicStructure');
 const { updatePackageJson } = require('../templates/packageJson');
 const { askUserWhereToOpen } = require('../utils/logging');
@@ -56,6 +57,9 @@ async function initProject(projectDirectory, userInput, options) {
   }
   setupStyles(userInput.styling);
   setupTesting(userInput.testingFramework);
+  if (userInput.useModuleFederation) {
+    setupModuleFederation();
+  }
 
   // Create atomic design structure
   createAtomicStructure();

--- a/src/setup/moduleFederation.js
+++ b/src/setup/moduleFederation.js
@@ -1,0 +1,31 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const ora = require('ora');
+
+function setupModuleFederation() {
+  const spinner = ora('🔗 Setting up Module Federation...').start();
+  try {
+    execSync('npm install --save-dev @originjs/vite-plugin-federation', { stdio: 'inherit' });
+
+    const configPath = path.resolve('vite.config.js');
+    let config = fs.readFileSync(configPath, 'utf8');
+
+    if (!config.includes('@originjs/vite-plugin-federation')) {
+      const importLine = "import federation from '@originjs/vite-plugin-federation';\n";
+      config = importLine + config;
+      config = config.replace(/plugins:\s*\[(.*?)\]/s, (match, p1) => {
+        const plugins = p1.trim();
+        return `plugins: [${plugins ? plugins + ', ' : ''}federation({})]`;
+      });
+      fs.writeFileSync(configPath, config);
+    }
+
+    spinner.succeed('🔗 Module Federation configured.');
+  } catch (error) {
+    spinner.fail('❌ Failed to set up Module Federation.');
+    console.error(error);
+  }
+}
+
+module.exports = { setupModuleFederation };


### PR DESCRIPTION
## Summary
- add optional module federation plugin setup for Vite
- include `@originjs/vite-plugin-federation` as a dev dependency
- call `setupModuleFederation` when requested
- clean up `vite.config.js` template

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649756c7148327a59258d91d41af3f