### PR TITLE
Add CLI flags documentation and help file

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,0 +1,9 @@
+# React Crafter CLI Help
+
+Usage:
+  npx react-crafter <project-directory> [options]
+
+Options:
+  --typescript       Scaffold the project using the TypeScript template
+  -V, --version      Output the version number
+  -h, --help         Display help information

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ npx react-crafter awesome-project
 
 During setup you'll select either JavaScript or TypeScript. React Crafter then calls `create-vite` with the matching template (`react` or `react-ts`) so you won't see any additional prompts.
 
+## CLI Flags
+
+React Crafter supports a few command line options:
+
+- `--typescript` – scaffold the project using the TypeScript template without a prompt.
+- `-V, --version` – output the CLI version.
+- `-h, --help` – display usage information.
+
+
 ## Commands
 
 Here’s a summary of the commands you can use after setting up your project:


### PR DESCRIPTION
## Summary
- document available command line options in README
- add a small `HELP.md` file describing CLI usage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649ade04088327be4e8b316be1f04d